### PR TITLE
Feat/#5/재촬영 유도 화면 구현

### DIFF
--- a/src/features/diagnosis/components/DiseaseResultInconclusiveLow.jsx
+++ b/src/features/diagnosis/components/DiseaseResultInconclusiveLow.jsx
@@ -1,5 +1,26 @@
-import { Body20 } from '@/shared/typography'
+import { Body20, Head25 } from '@/shared/typography'
+import Button from '@/shared/components/Button'
 
 export default function DiseaseResultInconclusiveLow() {
-  return <Body20>확률 20% 미만</Body20>
+  return (
+    <div className='flex flex-col justify-between'>
+      {/* 메인 영역 */}
+      <div className='flex flex-col justify-center items-center mt-[44px] gap-[27px] py-[27px] rounded-[10px] border border-[2px] border-percent'>
+        <Head25 className='text-gray-300'>병충해를 판별할 수 없어요 😢</Head25>
+
+        <Body20 className='text-center whitespace-pre-line'>
+          {`병충해가 의심되는 잎을\n확대해서 촬영해 주세요!`}
+        </Body20>
+      </div>
+
+      {/* 저장하기 버튼 */}
+      <Button
+        label='사진 다시 촬영하기'
+        size='large'
+        variant='primary'
+        className='self-center mt-[42px]'
+        onClick={() => console.log('사진 재촬영 클릭')}
+      />
+    </div>
+  )
 }

--- a/src/features/diagnosis/components/DiseaseResultInconclusiveMid.jsx
+++ b/src/features/diagnosis/components/DiseaseResultInconclusiveMid.jsx
@@ -1,5 +1,43 @@
-import { Body20 } from '@/shared/typography'
+import { Body20, Head25 } from '@/shared/typography'
+import Button from '@/shared/components/Button'
 
 export default function DiseaseResultInconclusiveMid() {
-  return <Body20>확률 20% 이상 30% 미만</Body20>
+  // TODO: 실제 데이터로 교체
+  const diseases = ['질병1', '질병2']
+  const confidences = [0, 0]
+
+  return (
+    <div className='flex flex-col justify-between'>
+      {/* 메인 영역 */}
+      <div className='flex flex-col justify-center items-center mt-[44px] gap-[27px] py-[27px] rounded-[10px] border border-[2px] border-percent'>
+        <Head25 className='text-gray-300'>병충해를 판별할 수 없어요 😢</Head25>
+
+        {/* 질병 후보 2개 */}
+        <div>
+          {diseases.map((disease, idx) => {
+            const rank = idx + 1
+
+            return (
+              <div key={idx} className='text-center text-xl leading-[1.56rem] text-gray-100'>
+                후보 {rank}. {disease} (예측 확률: {confidences[idx]}%)
+              </div>
+            )
+          })}
+        </div>
+
+        <Body20 className='text-center whitespace-pre-line'>
+          {`정확한 병충해 판별을 위해\n사진을 다시 촬영해 주세요!`}
+        </Body20>
+      </div>
+
+      {/* 저장하기 버튼 */}
+      <Button
+        label='사진 다시 촬영하기'
+        size='large'
+        variant='primary'
+        className='self-center mt-[42px]'
+        onClick={() => console.log('사진 재촬영 클릭')}
+      />
+    </div>
+  )
 }

--- a/src/features/diagnosis/pages/DiagnosisResultPage.jsx
+++ b/src/features/diagnosis/pages/DiagnosisResultPage.jsx
@@ -36,7 +36,7 @@ export default function DiagnosisResultPage() {
   }
 
   // 진단 케이스 (나중에 API 응답으로 교체)
-  const caseType = 'INCONCLUSIVE_MID'
+  const caseType = 'INCONCLUSIVE_LOW'
 
   return (
     <div className='py-[52px] flex flex-col h-full'>

--- a/src/features/diagnosis/pages/DiagnosisResultPage.jsx
+++ b/src/features/diagnosis/pages/DiagnosisResultPage.jsx
@@ -36,7 +36,7 @@ export default function DiagnosisResultPage() {
   }
 
   // 진단 케이스 (나중에 API 응답으로 교체)
-  const caseType = 'CERTAIN_DISEASE'
+  const caseType = 'INCONCLUSIVE_MID'
 
   return (
     <div className='py-[52px] flex flex-col h-full'>


### PR DESCRIPTION
## 📌 Related Issue
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요. -->
- closed #5 

## ✨ Work Description
<!-- 구현한 부분에 대해 설명해주세요. -->
- top1의 예측 확률 30% 미만의 진단 결과 화면 구현

## 📢 Notices
<!-- 리뷰어가 집중해서 봐줬으면 하는 부분이 있다면 작성해주세요. -->


## 📷 ScreenShot
<!-- UI 변경이 있다면 스크린샷 첨부해주세요. -->
<img width="500" height="600" alt="스크린샷 2025-12-04 오전 11 30 33" src="https://github.com/user-attachments/assets/d916e2d5-98d6-4128-a6da-ba128484c2ea" />
<img width="500" height="600" alt="image" src="https://github.com/user-attachments/assets/e78de652-a061-4c62-8563-c170ad93019f" />

