### PR TITLE
Feat/#17/진단 결과 부분 API 연동 및 UI 일부 수정

### DIFF
--- a/src/api/diagnosis.js
+++ b/src/api/diagnosis.js
@@ -20,3 +20,26 @@ export async function analyzeDiagnosis(imageFile) {
     throw handleApiError(error)
   }
 }
+
+// 진단 결과 저장 API
+export async function saveDiagnosis(tempDiagnosisId, folderId, imageSource = 'CAMERA') {
+  try {
+    const res = await client.post(
+      `/diagnoses/${tempDiagnosisId}`,
+      '', // 빈 body
+      {
+        params: {
+          folderId,
+          imageSource,
+        },
+        headers: {
+          'User-Id': env.userId,
+        },
+      },
+    )
+
+    return res.data.data
+  } catch (error) {
+    throw handleApiError(error)
+  }
+}

--- a/src/api/fertilizer.js
+++ b/src/api/fertilizer.js
@@ -1,0 +1,13 @@
+import client from './client'
+import { handleApiError } from '@/shared/utils/handleApiError'
+
+// 추천 비료 제품 조회 API
+export async function getFertilizerProducts() {
+  try {
+    const res = await client.get('/fertilizers/products')
+
+    return res.data.data
+  } catch (error) {
+    throw handleApiError(error)
+  }
+}

--- a/src/api/folder.js
+++ b/src/api/folder.js
@@ -1,0 +1,18 @@
+import env from '@/shared/config/env'
+import client from './client'
+import { handleApiError } from '@/shared/utils/handleApiError'
+
+// 사용자 폴더 목록 조회 API
+export async function getUserFolders() {
+  try {
+    const res = await client.get('/home/folders', {
+      headers: {
+        'User-Id': env.userId,
+      },
+    })
+
+    return res.data.data
+  } catch (error) {
+    throw handleApiError(error)
+  }
+}

--- a/src/features/diagnosis/components/DiseaseResultCertain.jsx
+++ b/src/features/diagnosis/components/DiseaseResultCertain.jsx
@@ -3,7 +3,7 @@ import ListBox from './ListBox'
 import ProductRecommendSection from './ProductRecommendSection'
 import Button from '@/shared/components/Button'
 
-export default function DiseaseResultCertain({ onSaveClick, primaryDisease }) {
+export default function DiseaseResultCertain({ onSaveClick, primaryDisease, products }) {
   if (!primaryDisease) return null
 
   const diseaseName = primaryDisease.diseaseName
@@ -41,7 +41,7 @@ export default function DiseaseResultCertain({ onSaveClick, primaryDisease }) {
         <ListBox title='이렇게 관리하는 게 좋아요!' items={guides} />
 
         {/* 추천 제품 영역 */}
-        <ProductRecommendSection />
+        <ProductRecommendSection products={products} />
       </div>
 
       {/* 저장하기 버튼 */}

--- a/src/features/diagnosis/components/DiseaseResultCertain.jsx
+++ b/src/features/diagnosis/components/DiseaseResultCertain.jsx
@@ -3,7 +3,7 @@ import ListBox from './ListBox'
 import ProductRecommendSection from './ProductRecommendSection'
 import Button from '@/shared/components/Button'
 
-export default function DiseaseResultCertain({ onSaveClick, primaryDisease, products }) {
+export default function DiseaseResultCertain({ onSaveClick, primaryDisease, products, crop }) {
   if (!primaryDisease) return null
 
   const diseaseName = primaryDisease.diseaseName
@@ -16,6 +16,9 @@ export default function DiseaseResultCertain({ onSaveClick, primaryDisease, prod
     <div className='flex flex-col justify-between'>
       {/* 내용 영역 */}
       <div>
+        {/* 작물 정보 */}
+        {crop && <Body18 className='text-gray-200 mb-[10px]'>작물: {crop}</Body18>}
+
         {/* 질병명 + 예측 신뢰도 */}
         <div className='flex gap-[14px] items-center mb-[10px]'>
           {/* 질병명 */}

--- a/src/features/diagnosis/components/DiseaseResultInconclusiveMid.jsx
+++ b/src/features/diagnosis/components/DiseaseResultInconclusiveMid.jsx
@@ -1,8 +1,8 @@
-import { Body20, Head25 } from '@/shared/typography'
+import { Body18, Body20, Head25 } from '@/shared/typography'
 import Button from '@/shared/components/Button'
 import { useNavigate } from 'react-router-dom'
 
-export default function DiseaseResultInconclusiveMid({ candidates = [] }) {
+export default function DiseaseResultInconclusiveMid({ candidates = [], crop }) {
   const navigate = useNavigate()
 
   const diseases = candidates.map((c) => c.diseaseName)
@@ -10,6 +10,9 @@ export default function DiseaseResultInconclusiveMid({ candidates = [] }) {
 
   return (
     <div className='flex flex-col justify-between'>
+      {/* 작물 정보 */}
+      {crop && <Body18 className='text-gray-200 mb-[10px]'>작물: {crop}</Body18>}
+
       {/* 메인 영역 */}
       <div className='flex flex-col justify-center items-center mt-[44px] gap-[27px] py-[27px] rounded-[10px] border border-[2px] border-percent'>
         <Head25 className='text-gray-300'>병충해를 판별할 수 없어요 😢</Head25>

--- a/src/features/diagnosis/components/DiseaseResultNoDisease.jsx
+++ b/src/features/diagnosis/components/DiseaseResultNoDisease.jsx
@@ -3,7 +3,7 @@ import ListBox from './ListBox'
 import ProductRecommendSection from './ProductRecommendSection'
 import Button from '@/shared/components/Button'
 
-export default function DiseaseResultNoDisease({ onSaveClick, careTips = [] }) {
+export default function DiseaseResultNoDisease({ onSaveClick, careTips = [], products }) {
   const guides = careTips
 
   return (
@@ -17,7 +17,7 @@ export default function DiseaseResultNoDisease({ onSaveClick, careTips = [] }) {
         <ListBox title='이렇게 예방할 수 있어요!' items={guides} />
 
         {/* 추천 제품 영역 */}
-        <ProductRecommendSection />
+        <ProductRecommendSection products={products} />
       </div>
 
       {/* 저장하기 버튼 */}

--- a/src/features/diagnosis/components/DiseaseResultNoDisease.jsx
+++ b/src/features/diagnosis/components/DiseaseResultNoDisease.jsx
@@ -1,15 +1,18 @@
-import { Head25 } from '@/shared/typography'
+import { Body18, Head25 } from '@/shared/typography'
 import ListBox from './ListBox'
 import ProductRecommendSection from './ProductRecommendSection'
 import Button from '@/shared/components/Button'
 
-export default function DiseaseResultNoDisease({ onSaveClick, careTips = [], products }) {
+export default function DiseaseResultNoDisease({ onSaveClick, careTips = [], products, crop }) {
   const guides = careTips
 
   return (
     <div className='flex flex-col justify-between'>
       {/* 내용 영역 */}
       <div>
+        {/* 작물 정보 */}
+        {crop && <Body18 className='text-gray-200 mb-[10px]'>작물: {crop}</Body18>}
+
         {/* 헤더 */}
         <Head25 className='text-gray-300 mb-[18px]'>작물이 건강합니다! 🌱</Head25>
 

--- a/src/features/diagnosis/components/DiseaseResultSuspicious.jsx
+++ b/src/features/diagnosis/components/DiseaseResultSuspicious.jsx
@@ -7,6 +7,7 @@ export default function DiseaseResultSuspicious({
   onSaveClick,
   candidates = [],
   primaryDisease = null,
+  products,
 }) {
   const diseases = candidates.map((c) => c.diseaseName)
   const confidences = candidates.map((c) => Math.round((c.confidenceScore ?? 0) * 100))
@@ -72,7 +73,7 @@ export default function DiseaseResultSuspicious({
         <ListBox title='이렇게 관리하는 게 좋아요!' items={guides} />
 
         {/* 추천 제품 영역 */}
-        <ProductRecommendSection />
+        <ProductRecommendSection products={products} />
       </div>
 
       {/* 저장하기 버튼 */}

--- a/src/features/diagnosis/components/DiseaseResultSuspicious.jsx
+++ b/src/features/diagnosis/components/DiseaseResultSuspicious.jsx
@@ -10,10 +10,13 @@ export default function DiseaseResultSuspicious({
   products,
   crop,
 }) {
-  const diseases = candidates.map((c) => c.diseaseName)
-  const confidences = candidates.map((c) => Math.round((c.confidenceScore ?? 0) * 100))
+  // '건강' 상태를 제외하고 질병 후보만 필터링
+  const diseaseCandidates = candidates.filter((c) => c.diseaseName !== '건강')
+
+  const diseases = diseaseCandidates.map((c) => c.diseaseName)
+  const confidences = diseaseCandidates.map((c) => Math.round((c.confidenceScore ?? 0) * 100))
   // 1순위 질병의 description이 없으면 primaryDisease의 description 사용
-  const descriptions = candidates.map((c, idx) => {
+  const descriptions = diseaseCandidates.map((c, idx) => {
     if (idx === 0 && !c.description && primaryDisease?.description) {
       return primaryDisease.description
     }
@@ -41,9 +44,10 @@ export default function DiseaseResultSuspicious({
         {/* 의심 질병 목록 */}
         <div className='flex flex-col px-[20px] py-[14px] mt-[19px] mb-[10px] gap-[16px] rounded-[10px] border border-[0.5px] border-gray-100'>
           {diseases.map((disease, idx) => {
-            const candidate = candidates[idx]
-            const rank = candidate?.rank ?? idx + 1
-            const rankColor = rankColorMap[rank] || 'text-gray-200'
+            const candidate = diseaseCandidates[idx]
+            // 필터링된 후보에 대해 1부터 시작하는 순위 재매핑
+            const displayRank = idx + 1
+            const rankColor = rankColorMap[displayRank] || 'text-gray-200'
 
             return (
               <div key={idx} className='flex flex-col gap-[9px]'>
@@ -51,7 +55,7 @@ export default function DiseaseResultSuspicious({
                 <div className='flex gap-[14px] items-center'>
                   {/* 순위 + 질병명 */}
                   <div className='flex gap-[8px]'>
-                    <Head25 className={rankColor}>{rank}순위</Head25>
+                    <Head25 className={rankColor}>{displayRank}순위</Head25>
                     <Head25 className='text-gray-300'>{disease}</Head25>
                   </div>
 

--- a/src/features/diagnosis/components/DiseaseResultSuspicious.jsx
+++ b/src/features/diagnosis/components/DiseaseResultSuspicious.jsx
@@ -8,10 +8,17 @@ export default function DiseaseResultSuspicious({
   candidates = [],
   primaryDisease = null,
   products,
+  crop,
 }) {
   const diseases = candidates.map((c) => c.diseaseName)
   const confidences = candidates.map((c) => Math.round((c.confidenceScore ?? 0) * 100))
-  const descriptions = candidates.map((c) => c.description ?? '')
+  // 1순위 질병의 description이 없으면 primaryDisease의 description 사용
+  const descriptions = candidates.map((c, idx) => {
+    if (idx === 0 && !c.description && primaryDisease?.description) {
+      return primaryDisease.description
+    }
+    return c.description ?? ''
+  })
   const causes = primaryDisease?.causes ?? []
   const guides = primaryDisease?.managementTips ?? []
 
@@ -25,6 +32,9 @@ export default function DiseaseResultSuspicious({
     <div className='flex flex-col justify-between'>
       {/* 내용 영역 */}
       <div>
+        {/* 작물 정보 */}
+        {crop && <Body18 className='text-gray-200 mb-[10px]'>작물: {crop}</Body18>}
+
         {/* 헤더 */}
         <Head25>병충해가 의심돼요! 😨</Head25>
 

--- a/src/features/diagnosis/components/ProductRecommendSection.jsx
+++ b/src/features/diagnosis/components/ProductRecommendSection.jsx
@@ -1,33 +1,16 @@
 import { Body18, Sub10, Sub12 } from '@/shared/typography'
 
-const mockProducts = [
-  {
-    id: 1,
-    name: 'OO 비료 1',
-    price: '₩12,000',
-    seller: '판매처 A',
-  },
-  {
-    id: 2,
-    name: 'OO 비료 2',
-    price: '₩15,500',
-    seller: '판매처 B',
-  },
-  {
-    id: 3,
-    name: 'OO 영양제',
-    price: '₩9,900',
-    seller: '판매처 C',
-  },
-  {
-    id: 4,
-    name: 'OO 완효성 비료',
-    price: '₩18,000',
-    seller: '판매처 D',
-  },
-]
+// 가격 포맷팅 함수
+function formatPrice(price) {
+  return `₩${price.toLocaleString()}`
+}
 
-export default function ProductRecommendSection({ products = mockProducts }) {
+export default function ProductRecommendSection({ products = [] }) {
+  // products가 없거나 빈 배열인 경우 아무것도 렌더링하지 않음
+  if (!products || products.length === 0) {
+    return null
+  }
+
   return (
     <div className='flex flex-col mt-[16px] gap-[8px]'>
       {/* 섹션 타이틀 */}
@@ -35,22 +18,30 @@ export default function ProductRecommendSection({ products = mockProducts }) {
 
       {/* 가로 스크롤 영역 */}
       <div className='flex overflow-x-auto gap-[7px] pb-[4px]'>
-        {products.map((item) => (
+        {products.map((item, index) => (
           <div
-            key={item.id}
+            key={index}
             className='flex-shrink-0 flex flex-col p-[5px] pb-[7px] gap-[5px] border border-gray-200 rounded-[5px] bg-white'
           >
-            {/* 제품 사진 (추후 실제 이미지로 교체) */}
-            <div className='w-[70px] h-[50px] bg-[#D9D9D9]' />
+            {/* 제품 사진 */}
+            {item.imageUrl ? (
+              <img
+                src={item.imageUrl}
+                alt={item.productName}
+                className='w-[70px] h-[50px] object-cover rounded'
+              />
+            ) : (
+              <div className='w-[70px] h-[50px] bg-[#D9D9D9] rounded' />
+            )}
 
             {/* 제품 설명 */}
             <div className='flex flex-col gap-[3px]'>
               {/* 제품명 */}
-              <Sub12 className='text-gray-300'>{item.name}</Sub12>
+              <Sub12 className='text-gray-300'>{item.productName}</Sub12>
               {/* 가격 */}
-              <Sub10 className='text-blue'>{item.price}</Sub10>
+              <Sub10 className='text-blue'>{formatPrice(item.price)}</Sub10>
               {/* 판매처 */}
-              <Sub10 className='text-gray-100'>{item.seller}</Sub10>
+              <Sub10 className='text-gray-100'>{item.unit}</Sub10>
             </div>
           </div>
         ))}

--- a/src/features/diagnosis/pages/DiagnosisResultPage.jsx
+++ b/src/features/diagnosis/pages/DiagnosisResultPage.jsx
@@ -181,7 +181,7 @@ export default function DiagnosisResultPage() {
 
       {/* 결과 내용 영역 */}
       <div className='mt-[18px] px-[20px] flex-1 overflow-y-auto'>
-        {renderResultSection(caseType, diagnosis, handleOpenFolderModal, products)}
+        {renderResultSection(caseType, diagnosis, handleOpenFolderModal, products, diagnosis?.crop)}
       </div>
 
       {/* 폴더 선택 모달 */}
@@ -207,7 +207,7 @@ export default function DiagnosisResultPage() {
 }
 
 // 케이스별 섹션 렌더 함수
-function renderResultSection(caseType, diagnosis, onSaveClick, products) {
+function renderResultSection(caseType, diagnosis, onSaveClick, products, crop) {
   switch (caseType) {
     case 'CERTAIN_DISEASE':
       return (
@@ -215,6 +215,7 @@ function renderResultSection(caseType, diagnosis, onSaveClick, products) {
           onSaveClick={onSaveClick}
           primaryDisease={diagnosis?.primaryDisease}
           products={products}
+          crop={crop}
         />
       )
 
@@ -225,6 +226,7 @@ function renderResultSection(caseType, diagnosis, onSaveClick, products) {
           candidates={diagnosis?.candidates || []}
           primaryDisease={diagnosis?.primaryDisease}
           products={products}
+          crop={crop}
         />
       )
 
@@ -234,6 +236,7 @@ function renderResultSection(caseType, diagnosis, onSaveClick, products) {
           onSaveClick={onSaveClick}
           careTips={diagnosis?.careTips || []}
           products={products}
+          crop={crop}
         />
       )
 
@@ -241,7 +244,7 @@ function renderResultSection(caseType, diagnosis, onSaveClick, products) {
       return <DiseaseResultInconclusiveLow />
 
     case 'INCONCLUSIVE_MID':
-      return <DiseaseResultInconclusiveMid candidates={diagnosis?.candidates || []} />
+      return <DiseaseResultInconclusiveMid candidates={diagnosis?.candidates || []} crop={crop} />
 
     default:
       return null

--- a/src/features/diagnosis/pages/DiagnosisResultPage.jsx
+++ b/src/features/diagnosis/pages/DiagnosisResultPage.jsx
@@ -4,6 +4,7 @@ import { H36 } from '@/shared/typography'
 
 import useApi from '@/shared/hooks/useApi'
 import { analyzeDiagnosis } from '@/api/diagnosis'
+import { getFertilizerProducts } from '@/api/fertilizer'
 import { dataUrlToFile } from '@/shared/utils/image'
 import Button from '@/shared/components/Button'
 
@@ -55,6 +56,14 @@ export default function DiagnosisResultPage() {
   // 진단 API 호출
   const { data: diagnosis, error, loading, execute } = useApi(analyzeDiagnosis)
 
+  // 비료 제품 API 호출
+  const {
+    data: products,
+    error: productsError,
+    loading: productsLoading,
+    execute: executeProducts,
+  } = useApi(getFertilizerProducts)
+
   // 폴더 선택 모달
   const [isFolderModalOpen, setIsFolderModalOpen] = useState(false)
   const [selectedFolderId, setSelectedFolderId] = useState(null)
@@ -68,12 +77,13 @@ export default function DiagnosisResultPage() {
     // TODO: 실제 진단 결과를 해당 폴더로 저장 API 호출
   }
 
-  // 페이지 진입 시 진단 요청
+  // 페이지 진입 시 진단 요청 및 비료 제품 조회
   useEffect(() => {
     if (!previewImage) return
     const file = dataUrlToFile(previewImage, 'capture.jpg')
     execute(file)
-  }, [previewImage, execute])
+    executeProducts()
+  }, [previewImage, execute, executeProducts])
 
   // 최종 이미지 URL (진단 이미지 > 프리뷰 이미지 > null)
   const imageUrl = diagnosis?.imageUrl ?? previewImage ?? null
@@ -126,7 +136,7 @@ export default function DiagnosisResultPage() {
 
       {/* 결과 내용 영역 */}
       <div className='mt-[18px] px-[20px] flex-1 overflow-y-auto'>
-        {renderResultSection(caseType, diagnosis, handleOpenFolderModal)}
+        {renderResultSection(caseType, diagnosis, handleOpenFolderModal, products)}
       </div>
 
       {/* 폴더 선택 모달 */}
@@ -144,13 +154,14 @@ export default function DiagnosisResultPage() {
 }
 
 // 케이스별 섹션 렌더 함수
-function renderResultSection(caseType, diagnosis, onSaveClick) {
+function renderResultSection(caseType, diagnosis, onSaveClick, products) {
   switch (caseType) {
     case 'CERTAIN_DISEASE':
       return (
         <DiseaseResultCertain
           onSaveClick={onSaveClick}
           primaryDisease={diagnosis?.primaryDisease}
+          products={products}
         />
       )
 
@@ -160,12 +171,17 @@ function renderResultSection(caseType, diagnosis, onSaveClick) {
           onSaveClick={onSaveClick}
           candidates={diagnosis?.candidates || []}
           primaryDisease={diagnosis?.primaryDisease}
+          products={products}
         />
       )
 
     case 'NO_DISEASE':
       return (
-        <DiseaseResultNoDisease onSaveClick={onSaveClick} careTips={diagnosis?.careTips || []} />
+        <DiseaseResultNoDisease
+          onSaveClick={onSaveClick}
+          careTips={diagnosis?.careTips || []}
+          products={products}
+        />
       )
 
     case 'INCONCLUSIVE_LOW':

--- a/src/features/diagnosis/pages/DiagnosisResultPage.jsx
+++ b/src/features/diagnosis/pages/DiagnosisResultPage.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
-import { H36 } from '@/shared/typography'
+import { Body20, H36 } from '@/shared/typography'
 
 import useApi from '@/shared/hooks/useApi'
 import { analyzeDiagnosis, saveDiagnosis } from '@/api/diagnosis'
@@ -140,7 +140,13 @@ export default function DiagnosisResultPage() {
   if (loading) {
     return (
       <div className='py-[52px] flex flex-col h-full'>
-        <H36 className='p-[15px] text-brand'>진단 결과</H36>
+        {/* 헤더 */}
+        <div className='flex items-center justify-between p-[15px]'>
+          <H36 className='text-brand'>진단 결과</H36>
+          <button className='cursor-pointer' onClick={() => navigate('/')}>
+            <Body20 className='text-gray-200'>홈으로</Body20>
+          </button>
+        </div>
         <div className='flex-1 flex items-center justify-center'>
           <p className='text-gray-200 text-body-20'>
             식물 상태를 분석 중입니다… 잠시만 기다려 주세요 🌱
@@ -154,7 +160,13 @@ export default function DiagnosisResultPage() {
   if (error) {
     return (
       <div className='py-[52px] flex flex-col h-full'>
-        <H36 className='p-[15px] text-brand'>진단 결과</H36>
+        {/* 헤더 */}
+        <div className='flex items-center justify-between p-[15px]'>
+          <H36 className='text-brand'>진단 결과</H36>
+          <button className='cursor-pointer' onClick={() => navigate('/')}>
+            <Body20 className='text-gray-200'>홈으로</Body20>
+          </button>
+        </div>
         <div className='flex-1 flex flex-col items-center justify-center gap-4'>
           <p className='text-red-500 text-body-20'>
             {error.message || '진단 중 오류가 발생했습니다.'}
@@ -168,7 +180,10 @@ export default function DiagnosisResultPage() {
   return (
     <div className='py-[52px] flex flex-col h-full'>
       {/* 헤더 */}
-      <H36 className='p-[15px] text-brand'>진단 결과</H36>
+      <div className='flex items-center justify-between p-[15px]'>
+        <H36 className='text-brand'>진단 결과</H36>
+        <Button label='홈으로' size='small' variant='secondary' onClick={() => navigate('/')} />
+      </div>
 
       {/* 사진 영역 */}
       <div className='relative h-[200px] overflow-hidden bg-gray-200 flex items-center justify-center'>

--- a/src/features/diagnosis/pages/DiagnosisResultPage.jsx
+++ b/src/features/diagnosis/pages/DiagnosisResultPage.jsx
@@ -3,11 +3,12 @@ import { useLocation, useNavigate } from 'react-router-dom'
 import { H36 } from '@/shared/typography'
 
 import useApi from '@/shared/hooks/useApi'
-import { analyzeDiagnosis } from '@/api/diagnosis'
+import { analyzeDiagnosis, saveDiagnosis } from '@/api/diagnosis'
 import { getFertilizerProducts } from '@/api/fertilizer'
 import { getUserFolders } from '@/api/folder'
 import { dataUrlToFile } from '@/shared/utils/image'
 import Button from '@/shared/components/Button'
+import CompleteModal from '@/shared/components/CompleteModal'
 
 // 결과 섹션별 컴포넌트
 import DiseaseResultCertain from '@/features/diagnosis/components/DiseaseResultCertain'
@@ -74,21 +75,51 @@ export default function DiagnosisResultPage() {
     execute: executeFolders,
   } = useApi(getUserFolders)
 
+  // 진단 결과 저장 API 호출
+  const {
+    data: savedDiagnosis,
+    error: saveError,
+    loading: saveLoading,
+    execute: executeSave,
+  } = useApi(saveDiagnosis)
+
   // 폴더 선택 모달
   const [isFolderModalOpen, setIsFolderModalOpen] = useState(false)
   const [selectedFolderId, setSelectedFolderId] = useState(null)
+
+  // 저장 완료 모달
+  const [isCompleteModalOpen, setIsCompleteModalOpen] = useState(false)
 
   const handleOpenFolderModal = () => {
     setIsFolderModalOpen(true)
     // 모달이 열릴 때 폴더 목록 조회
     executeFolders()
   }
-  const handleCloseFolderModal = () => setIsFolderModalOpen(false)
-
-  const handleConfirmFolder = (folderId) => {
-    console.log('저장할 폴더:', folderId)
+  const handleCloseFolderModal = () => {
     setIsFolderModalOpen(false)
-    // TODO: 실제 진단 결과를 해당 폴더로 저장 API 호출
+    setSelectedFolderId(null) // 모달 닫을 때 선택 초기화
+  }
+
+  const handleConfirmFolder = async (folderId) => {
+    if (!diagnosis?.tempDiagnosisId) {
+      console.error('진단 결과가 없습니다.')
+      return
+    }
+
+    try {
+      await executeSave(diagnosis.tempDiagnosisId, folderId, 'CAMERA')
+      setIsFolderModalOpen(false)
+      setIsCompleteModalOpen(true)
+      setSelectedFolderId(null) // 저장 후 선택 초기화
+    } catch (error) {
+      console.error('진단 결과 저장 실패:', error)
+      // 에러는 useApi에서 관리되므로 여기서는 로그만 출력
+      // 저장 실패 시에도 모달은 유지 (사용자가 다시 시도할 수 있도록)
+    }
+  }
+
+  const handleCloseCompleteModal = () => {
+    setIsCompleteModalOpen(false)
   }
 
   // 페이지 진입 시 진단 요청 및 비료 제품 조회
@@ -162,6 +193,14 @@ export default function DiagnosisResultPage() {
         selectedFolderId={selectedFolderId}
         onSelectFolder={setSelectedFolderId}
         onConfirm={handleConfirmFolder}
+        isLoading={saveLoading}
+      />
+
+      {/* 저장 완료 모달 */}
+      <CompleteModal
+        isOpen={isCompleteModalOpen}
+        onClose={handleCloseCompleteModal}
+        title='진단 기록이 저장되었습니다!'
       />
     </div>
   )

--- a/src/features/diagnosis/pages/DiagnosisResultPage.jsx
+++ b/src/features/diagnosis/pages/DiagnosisResultPage.jsx
@@ -5,6 +5,7 @@ import { H36 } from '@/shared/typography'
 import useApi from '@/shared/hooks/useApi'
 import { analyzeDiagnosis } from '@/api/diagnosis'
 import { getFertilizerProducts } from '@/api/fertilizer'
+import { getUserFolders } from '@/api/folder'
 import { dataUrlToFile } from '@/shared/utils/image'
 import Button from '@/shared/components/Button'
 
@@ -16,13 +17,14 @@ import DiseaseResultNoDisease from '@/features/diagnosis/components/DiseaseResul
 import DiseaseResultSuspicious from '@/features/diagnosis/components/DiseaseResultSuspicious'
 import FolderSelectModal from '@/shared/components/FolderSelectModal'
 
-// TODO: 추후 서버에서 불러오기
-const mockFolders = [
-  { id: 1, name: '옥수수' },
-  { id: 2, name: '포도' },
-  { id: 3, name: '사과' },
-  { id: 4, name: '토마토' },
-]
+// API 응답 데이터를 FolderSelectModal 형식으로 변환
+function transformFoldersData(apiData) {
+  if (!apiData?.plantFolders) return []
+  return apiData.plantFolders.map((folder) => ({
+    id: folder.folderId,
+    name: folder.folderName,
+  }))
+}
 
 // 서버 caseType -> UI caseType 매핑
 function mapServerCaseTypeToUi(raw) {
@@ -64,11 +66,23 @@ export default function DiagnosisResultPage() {
     execute: executeProducts,
   } = useApi(getFertilizerProducts)
 
+  // 폴더 목록 API 호출
+  const {
+    data: foldersData,
+    error: foldersError,
+    loading: foldersLoading,
+    execute: executeFolders,
+  } = useApi(getUserFolders)
+
   // 폴더 선택 모달
   const [isFolderModalOpen, setIsFolderModalOpen] = useState(false)
   const [selectedFolderId, setSelectedFolderId] = useState(null)
 
-  const handleOpenFolderModal = () => setIsFolderModalOpen(true)
+  const handleOpenFolderModal = () => {
+    setIsFolderModalOpen(true)
+    // 모달이 열릴 때 폴더 목록 조회
+    executeFolders()
+  }
   const handleCloseFolderModal = () => setIsFolderModalOpen(false)
 
   const handleConfirmFolder = (folderId) => {
@@ -144,7 +158,7 @@ export default function DiagnosisResultPage() {
         emptyTitle='폴더를 선택해 주세요'
         isOpen={isFolderModalOpen}
         onClose={handleCloseFolderModal}
-        folders={mockFolders}
+        folders={transformFoldersData(foldersData)}
         selectedFolderId={selectedFolderId}
         onSelectFolder={setSelectedFolderId}
         onConfirm={handleConfirmFolder}

--- a/src/shared/components/FolderSelectModal.jsx
+++ b/src/shared/components/FolderSelectModal.jsx
@@ -14,11 +14,12 @@ export default function FolderSelectModal({
   onConfirm, // (id) => void
   getTitleText = undefined,
   emptyTitle = '폴더를 선택해 주세요',
+  isLoading = false, // 저장 중 로딩 상태
 }) {
   const [keyword, setKeyword] = useState('')
 
   const selectedFolder = folders?.find((f) => f.id === selectedFolderId)
-  const isDisabled = !selectedFolderId
+  const isDisabled = !selectedFolderId || isLoading
 
   // 제목 텍스트/색상
   const title = useMemo(() => {
@@ -121,7 +122,7 @@ export default function FolderSelectModal({
 
         {/* 저장하기 버튼 */}
         <Button
-          label='저장하기'
+          label={isLoading ? '저장 중...' : '저장하기'}
           size='small'
           variant={isDisabled ? 'secondary' : 'primary'}
           className='mt-[42px] self-center'

--- a/src/shared/components/FolderSelectModal.jsx
+++ b/src/shared/components/FolderSelectModal.jsx
@@ -94,11 +94,12 @@ export default function FolderSelectModal({
           </div>
 
           {/* 폴더 리스트 */}
-          <div className='rounded-[10px] bg-brand-light px-[15px] py-[10px]'>
+          <div className='rounded-[10px] bg-brand-light px-[15px] py-[10px] max-h-[170px] overflow-y-auto'>
             {filteredFolders?.map((folder, idx) => {
               const isSelected = folder.id === selectedFolderId
               const base = 'flex w-full items-center py-[10px] text-[20px] leading-5'
               const color = isSelected ? 'text-brand' : 'text-gray-200'
+              // 마지막 아이템이 아닐 때만 border 추가 (스크롤 시 마지막 아이템도 border가 보이지 않도록)
               const border = idx === filteredFolders.length - 1 ? '' : 'border-b border-gray-100'
 
               return (


### PR DESCRIPTION
## 📌 Related Issue
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요. -->
- #17 
- closed #25 

## ✨ Work Description
<!-- 구현한 부분에 대해 설명해주세요. -->
- 추천 비료 제품 조회 API 연동
- **사용자 폴더 목록 조회 API 연동** -> 폴더 선택 모달창에서 필요하여 연동했습니다..!
- 진단 결과 저장 API 연동
- 폴더 선택 모달 스크롤 기능 추가 (아이템 4개 이상일 때 최대 높이 제한)
- **진단 결과 화면 개선**
  - 작물명 정보 표시 추가
  - `SUSPICIOUS` 케이스에서 1순위 질병에 대한 설명 추가 및 '건강' 상태 필터링(보이지 않게)
  - 헤더 우측에 '홈으로' 텍스트 버튼 추가

## 📢 Notices
<!-- 리뷰어가 집중해서 봐줬으면 하는 부분이 있다면 작성해주세요. -->
- 사용자 폴더 목록 조회 API 연동을 해둬서 홈화면에서 조회할 때도 같은 함수 사용하면 될 것 같습니다

## 📷 ScreenShot
<!-- UI 변경이 있다면 스크린샷 첨부해주세요. -->

